### PR TITLE
Strip TestEnableDevelopmentNetworkProtocols if default source config has p2p enabled

### DIFF
--- a/.github/scripts/download-all.sh
+++ b/.github/scripts/download-all.sh
@@ -41,7 +41,8 @@ then
 
   # Transform defaults to disable p2p
   jq -nj --argjson address $(echo $ACCESS_POINT | jq '.address') --argjson port $(echo $ACCESS_POINT | jq '.port') '{"Producers": [{"addr": $address, "port": $port, "valency": 1 }]}' > network/$CARDANO_NETWORK/cardano-node/topology.json
-  echo $NODE_CONFIG | jq '.EnableP2P = false' | jq '.' > network/$CARDANO_NETWORK/cardano-node/config.json
+  # See https://github.com/input-output-hk/cardano-node/blob/0681cdeb07d81b3b088a6c14e703d03751c3d25d/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs#L366
+  echo $NODE_CONFIG | jq '.EnableP2P = false | del(.TestEnableDevelopmentNetworkProtocols)'> network/$CARDANO_NETWORK/cardano-node/config.json
   echo $DB_SYNC_CONFIG | jq '.' > network/$CARDANO_NETWORK/cardano-db-sync/config.json
 else
   # Source config doesn't have p2p enabled, so no further transformation required


### PR DESCRIPTION
This isn't strictly necessary given the logic should ignore this config option, however, it's
only present when p2p is enabled, so I feel it's safer to delete for better alignment. The 
current implementation is also unnecessarily invoking `jq` for assumed formatting, so this is
also removed.