### PR TITLE
Force LF line endings to ensure config hash match

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
This forces (mainly Windows) to clone with LF line endings so that the config hashes match. This is useful so one can run a cardano node in docker and directly map the config in their machine as a volume.