### PR TITLE
fix: Cardano configuration file when no Conway genesis available

### DIFF
--- a/.github/scripts/download-all.sh
+++ b/.github/scripts/download-all.sh
@@ -13,7 +13,7 @@ mkdir -p \
 
 wget -q $CARDANO_CONFIG_URL/$CARDANO_NETWORK/topology.json -O network/$CARDANO_NETWORK/cardano-node/topology.json
 wget -qO- $CARDANO_CONFIG_URL/$CARDANO_NETWORK/config.json \
-  | jq '.ByronGenesisFile = "../genesis/byron.json" | .ShelleyGenesisFile = "../genesis/shelley.json" | .AlonzoGenesisFile = "../genesis/alonzo.json" | .ConwayGenesisFile = "../genesis/conway.json"' \
+  | jq '.ByronGenesisFile = "../genesis/byron.json" | .ShelleyGenesisFile = "../genesis/shelley.json" | .AlonzoGenesisFile = "../genesis/alonzo.json"' \
   | jq '.' > network/$CARDANO_NETWORK/cardano-node/config.json
 wget -qO- $CARDANO_CONFIG_URL/$CARDANO_NETWORK/db-sync-config.json \
   | jq '.NodeConfigFile = "../cardano-node/config.json"' \
@@ -27,4 +27,10 @@ wget -q $CARDANO_CONFIG_URL/$CARDANO_NETWORK/shelley-genesis.json -O network/$CA
 wget -q $CARDANO_CONFIG_URL/$CARDANO_NETWORK/alonzo-genesis.json -O network/$CARDANO_NETWORK/genesis/alonzo.json
 if wget --spider $CARDANO_CONFIG_URL/$CARDANO_NETWORK/conway-genesis.json 2>/dev/null; then
   wget -q $CARDANO_CONFIG_URL/$CARDANO_NETWORK/conway-genesis.json -O network/$CARDANO_NETWORK/genesis/conway.json
+  mv network/$CARDANO_NETWORK/cardano-node/config.json network/$CARDANO_NETWORK/cardano-node/config.json.tmp
+  cat network/$CARDANO_NETWORK/cardano-node/config.json.tmp \
+  | jq '.ConwayGenesisFile = "../genesis/conway.json"' \
+  | jq '.' > network/$CARDANO_NETWORK/cardano-node/config.json
+  rm network/$CARDANO_NETWORK/cardano-node/config.json.tmp
 fi
+


### PR DESCRIPTION
## Content

The `download-all.sh` script was always adding a `ConwayGenesisFile: ../genesis/conway.json` entry to the `cardano-node/config.json` file of the network.

With this fix, this is the case only if the Conway genesis file exists in the **Cardano Operations Book**.